### PR TITLE
[MKT-158]: fix/remove white space when the user download files

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -48,6 +48,11 @@
   transition-timing-function: ease-in-out;
 }
 
+iframe {
+  overflow: hidden;
+  height: 0;
+}
+
 @keyframes FadeIn {
   0% {
     opacity: 0;


### PR DESCRIPTION
In this PR we remove the blank space created under the main component. 

This white space was created by two iframes, so we hide the iframes from global css file to avoid it.