### PR TITLE
[_]: hotfix/react-dropzone problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "phosphor-react": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-dropzone": "^14.2.1",
+    "react-dropzone": "14.2.1",
     "react-hot-toast": "^2.2.0",
     "react-markdown": "^8.0.3",
     "react-router-dom": "6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10750,7 +10750,7 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-dropzone@^14.2.1:
+react-dropzone@14.2.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.1.tgz#aad17e06290723358398a7be76fb38ecf6d77c1a"
   integrity sha512-jzX6wDtAjlfwZ+Fbg+G17EszWUkQVxhMTWMfAC9qSUq7II2pKglHA8aarbFKl0mLpRPDaNUcy+HD/Sf4gkf76Q==


### PR DESCRIPTION
This PR fixes `react-dropzone` to v14.2.1 due to a bug in the new version when dragging and dropping files. When the user dragged and dropped some files, they were grouped in a folder named by a dot (.). This caused problems when downloading the content as there is no such folder.