### PR TITLE
[MKT-897]feat/Open link in new tab and simplify URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { FilesProvider } from './contexts/Files';
 import DownloadView from './views/DownloadView';
 import HomeView from './views/HomeView';
 import NotFoundView from './views/NotFoundView';
-import { useEffect } from 'react';
+import { cleanUrlParam } from './utils/cleanUrl';
 
 function DownloadRedirectWrapper() {
   const { sendId } = useParams();
@@ -16,27 +16,7 @@ function DownloadRedirectWrapper() {
 }
 
 function App() {
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    let hadChanges = false;
-
-    const currentKeys = Array.from(url.searchParams.keys());
-
-    currentKeys.forEach((param) => {
-      if (param === '_gl' || param === '_gcl_au' || param === '_fplc' || param.startsWith('_ga')) {
-        url.searchParams.delete(param);
-        hadChanges = true;
-      }
-    });
-
-    if (hadChanges) {
-      const newUrl = url.searchParams.toString()
-        ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
-        : `${url.pathname}${url.hash}`;
-
-      window.history.replaceState({}, document.title, newUrl);
-    }
-  }, []);
+  cleanUrlParam();
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,11 +18,12 @@ function DownloadRedirectWrapper() {
 function App() {
   useEffect(() => {
     const url = new URL(window.location.href);
-    const parametersToClear = ['_gl', '_gcl_au', '_ga'];
     let hadChanges = false;
 
-    parametersToClear.forEach((param) => {
-      if (url.searchParams.has(param)) {
+    const currentKeys = Array.from(url.searchParams.keys());
+
+    currentKeys.forEach((param) => {
+      if (param === '_gl' || param === '_gcl_au' || param === '_fplc' || param.startsWith('_ga')) {
         url.searchParams.delete(param);
         hadChanges = true;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { FilesProvider } from './contexts/Files';
 import DownloadView from './views/DownloadView';
 import HomeView from './views/HomeView';
 import NotFoundView from './views/NotFoundView';
+import { useEffect } from 'react';
 import { cleanUrlParam } from './utils/cleanUrl';
 
 function DownloadRedirectWrapper() {
@@ -16,7 +17,9 @@ function DownloadRedirectWrapper() {
 }
 
 function App() {
-  cleanUrlParam();
+  useEffect(() => {
+    cleanUrlParam();
+  }, []);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { FilesProvider } from './contexts/Files';
 import DownloadView from './views/DownloadView';
 import HomeView from './views/HomeView';
 import NotFoundView from './views/NotFoundView';
+import { useEffect } from 'react';
 
 function DownloadRedirectWrapper() {
   const { sendId } = useParams();
@@ -15,6 +16,27 @@ function DownloadRedirectWrapper() {
 }
 
 function App() {
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const parametersToClear = ['_gl', '_gcl_au', '_ga'];
+    let hadChanges = false;
+
+    parametersToClear.forEach((param) => {
+      if (url.searchParams.has(param)) {
+        url.searchParams.delete(param);
+        hadChanges = true;
+      }
+    });
+
+    if (hadChanges) {
+      const newUrl = url.searchParams.toString()
+        ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
+        : `${url.pathname}${url.hash}`;
+
+      window.history.replaceState({}, document.title, newUrl);
+    }
+  }, []);
+
   return (
     <>
       <BrowserRouter>

--- a/src/utils/cleanUrl.ts
+++ b/src/utils/cleanUrl.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+/**
+ * Remove Google Analytics/Tag Manager tracking query parameters
+ * to keep the URL looking clean for the users after page has loaded
+ */
+
+export function cleanUrlParam() {
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    let hadChanges = false;
+
+    const currentKeys = Array.from(url.searchParams.keys());
+
+    currentKeys.forEach((param) => {
+      if (param === '_gl' || param === '_gcl_au' || param === '_fplc' || param.startsWith('_ga')) {
+        url.searchParams.delete(param);
+        hadChanges = true;
+      }
+    });
+
+    if (hadChanges) {
+      const newUrl = url.searchParams.toString()
+        ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
+        : `${url.pathname}${url.hash}`;
+
+      window.history.replaceState({}, document.title, newUrl);
+    }
+  }, []);
+}

--- a/src/utils/cleanUrl.ts
+++ b/src/utils/cleanUrl.ts
@@ -1,30 +1,26 @@
-import { useEffect } from 'react';
-
 /**
  * Remove Google Analytics/Tag Manager tracking query parameters
  * to keep the URL looking clean for the users after page has loaded
  */
 
 export function cleanUrlParam() {
-  useEffect(() => {
-    const url = new URL(window.location.href);
-    let hadChanges = false;
+  const url = new URL(window.location.href);
+  let hadChanges = false;
 
-    const currentKeys = Array.from(url.searchParams.keys());
+  const currentKeys = Array.from(url.searchParams.keys());
 
-    currentKeys.forEach((param) => {
-      if (param === '_gl' || param === '_gcl_au' || param === '_fplc' || param.startsWith('_ga')) {
-        url.searchParams.delete(param);
-        hadChanges = true;
-      }
-    });
-
-    if (hadChanges) {
-      const newUrl = url.searchParams.toString()
-        ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
-        : `${url.pathname}${url.hash}`;
-
-      window.history.replaceState({}, document.title, newUrl);
+  currentKeys.forEach((param) => {
+    if (param === '_gl' || param === '_gcl_au' || param === '_fplc' || param.startsWith('_ga')) {
+      url.searchParams.delete(param);
+      hadChanges = true;
     }
-  }, []);
+  });
+
+  if (hadChanges) {
+    const newUrl = url.searchParams.toString()
+      ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
+      : `${url.pathname}${url.hash}`;
+
+    window.history.replaceState({}, document.title, newUrl);
+  }
 }


### PR DESCRIPTION
## Description

Clear the parameters of google analytics and google tags manager in url section, so the user don't see a super long url. 

## Changes Made
In the App.tsx:
1. Extracts current URL search parameters once the component mounts.
2. Delete GTM parameters (_gl, _gcl_au) and any keys starting with _ga (handling dynamic analytics IDs).
3. Rebuilds the URL, preserving non-Google parameters and the navigation anchor (url.hash).
4. Updates the browser's address bar seamlessly using window.history.replaceState.